### PR TITLE
Add resolver tests, cleaning await service functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This code ~hype~ boilerplate was created to assist on the development of Node.js
 ## How to use this boilerplate
 
 To use Lilium, it is recommeded that you fork / clone the repository localy and use its strucutre on your application. Rewrite the domain objects for your case but use the already developed tests, repositories and services to increase the development speed.
-Some services like database infrastructure and authorization will be wired so you can use it with minimal setup if you are on AWS. This setup will be presented [below](#Deployment) as soon as we finish the first project cycle.
+Some services like database infrastructure and authorization will be wired so you can use it with minimal setup if you are on AWS. This setup will be presented [below](#deployment) as soon as we finish the first project cycle.
 
 ## Public domain
 

--- a/src/application/resolvers.js
+++ b/src/application/resolvers.js
@@ -4,6 +4,6 @@ import meditationResolvers from 'domain/application/meditation/resolvers'
 
 export default mergeAll([
   {},
-  meditationResolvers,
-  actResolvers,
+  { Meditation: meditationResolvers },
+  { Act: actResolvers },
 ])

--- a/src/domain/application/act/factory.js
+++ b/src/domain/application/act/factory.js
@@ -1,7 +1,7 @@
 import casual from 'casual'
 import factoryFactory from 'infrastructure/factoryFactory'
 
-casual.define('createActInput', (title, shortDescription, meditationId, index, textBody, audioTrackUrl, videoTrackUrl) => ({
+const createActInput = (title, shortDescription, meditationId, index, textBody, audioTrackUrl, videoTrackUrl) => ({
   title: title || casual.word,
   shortDescription: shortDescription || casual.sentence,
   meditationId: meditationId || casual.uuid,
@@ -9,10 +9,10 @@ casual.define('createActInput', (title, shortDescription, meditationId, index, t
   textBody: textBody || casual.sentences(3),
   audioTrackUrl: audioTrackUrl || casual.url,
   videoTrackUrl: videoTrackUrl || casual.url,
-}))
-export const createActInputFactory = factoryFactory(casual.createActInput)
+})
+export const createActInputFactory = factoryFactory(createActInput)
 
-casual.define('updateActInput', (id, title, shortDescription, index, textBody, audioTrackUrl, videoTrackUrl) => ({
+const updateActInput = (id, title, shortDescription, index, textBody, audioTrackUrl, videoTrackUrl) => ({
   id: id || casual.uuid,
   title: title || casual.word,
   shortDescription: shortDescription || casual.sentence,
@@ -20,5 +20,5 @@ casual.define('updateActInput', (id, title, shortDescription, index, textBody, a
   textBody: textBody || casual.sentences(3),
   audioTrackUrl: audioTrackUrl || casual.url,
   videoTrackUrl: videoTrackUrl || casual.url,
-}))
-export const updateActInputFactory = factoryFactory(casual.updateActInput)
+})
+export const updateActInputFactory = factoryFactory(updateActInput)

--- a/src/domain/application/act/mutations.test.js
+++ b/src/domain/application/act/mutations.test.js
@@ -1,0 +1,59 @@
+import { MongoClient } from 'mongodb'
+import {
+  createActInputFactory,
+  updateActInputFactory,
+} from 'domain/application/act/factory'
+import Act from 'domain/model/act'
+import actFactory from 'domain/model/act/factory'
+import { createLoaders } from 'application'
+import ActMutations from 'domain/application/act/mutations'
+
+describe('ActMutations', () => {
+  let connection
+  let db
+  let loaders
+  let actCollection
+  const _ = undefined
+
+  beforeAll(async () => {
+    connection = await MongoClient.connect(global.MONGO_URI, { useNewUrlParser: true })
+    db = await connection.db(global.MONGO_DB_NAME)
+    loaders = createLoaders(db)
+    actCollection = db.collection(Act.name.toLowerCase())
+  })
+
+  beforeEach(async () => {
+    await actCollection.removeMany()
+  })
+
+  afterAll(async () => {
+    await connection.close()
+    await db.close()
+  })
+
+  it('should create an Act domain object', async () => {
+    const mockCreateActInput = createActInputFactory()
+    const insertedAct = await ActMutations.createAct(_, { input: mockCreateActInput }, { db, loaders })
+    expect(insertedAct).toEqual(mockCreateActInput)
+    const actCollectionDocs = await actCollection.find().toArray()
+    expect(actCollectionDocs.length).toEqual(1)
+    expect(actCollectionDocs[0]).toEqual(insertedAct)
+  })
+
+  it('should update an Act domain object', async () => {
+    const mockAct = actFactory()
+    const mockUpdateActInput = updateActInputFactory(1, mockAct._id)
+    await actCollection.insertOne(mockAct.toJSON())
+    const updatedAct = await ActMutations.updateAct(_, { input: mockUpdateActInput }, { db, loaders })
+    expect({ ...mockUpdateActInput, meditationId: updatedAct.meditationId, _id: mockUpdateActInput.id })
+      .toEqual(expect.objectContaining(updatedAct))
+  })
+
+  it('should delete one Act domain object given id', async () => {
+    const mockActs = actFactory(2, _, _, _, 'foo')
+    await actCollection.insertMany(mockActs.map(mockAct => mockAct.toJSON()))
+    await ActMutations.deleteAct(_, { id: mockActs[0]._id }, { db, loaders })
+    const actCollectionDocs = await actCollection.find().toArray()
+    expect(actCollectionDocs.length).toEqual(1)
+  })
+})

--- a/src/domain/application/act/resolvers.js
+++ b/src/domain/application/act/resolvers.js
@@ -1,10 +1,8 @@
 export default {
-  Act: {
-    id(act) {
-      return act._id
-    },
-    meditation(act, _, context) {
-      return context.loaders.meditationLoader.load(act.meditationId)
-    },
+  id(act) {
+    return act._id
+  },
+  meditation(act, _, context) {
+    return context.loaders.meditationLoader.load(act.meditationId)
   },
 }

--- a/src/domain/application/act/resolvers.test.js
+++ b/src/domain/application/act/resolvers.test.js
@@ -1,0 +1,50 @@
+import { MongoClient } from 'mongodb'
+import Act from 'domain/model/act'
+import Meditation from 'domain/model/meditation'
+import actFactory from 'domain/model/act/factory'
+import meditationFactory from 'domain/model/meditation/factory'
+import { createLoaders } from 'application'
+import actResolvers from 'domain/application/act/resolvers'
+
+describe('ActResolvers', () => {
+  let connection
+  let db
+  let loaders
+  let actCollection
+  let meditationCollection
+  const _ = undefined
+
+  beforeAll(async () => {
+    connection = await MongoClient.connect(global.MONGO_URI, { useNewUrlParser: true })
+    db = await connection.db(global.MONGO_DB_NAME)
+    loaders = createLoaders(db)
+    actCollection = db.collection(Act.name.toLowerCase())
+    meditationCollection = db.collection(Meditation.name.toLowerCase())
+  })
+
+  beforeEach(async () => {
+    await actCollection.removeMany()
+    await meditationCollection.removeMany()
+  })
+
+  afterAll(async () => {
+    await connection.close()
+    await db.close()
+  })
+
+  it('should return an Act domain object id', async () => {
+    const mockAct = actFactory()
+    const resolvedActId = actResolvers.id(mockAct)
+    expect(resolvedActId).toEqual(mockAct._id)
+  })
+
+  it('should return one Meditation domain object given and Act domain object', async () => {
+    const mockAct = actFactory(1, _, _, _, 'foo')
+    const mockMeditation = meditationFactory(1, 'foo')
+    await actCollection.insertOne(mockAct.toJSON())
+    await meditationCollection.insertOne(mockMeditation.toJSON())
+    const loadedMeditation = await actResolvers.meditation(mockAct, _, { db, loaders })
+    expect(loadedMeditation)
+      .toEqual(expect.objectContaining(mockMeditation.toJSON()))
+  })
+})

--- a/src/domain/application/meditation/mutations.test.js
+++ b/src/domain/application/meditation/mutations.test.js
@@ -1,0 +1,72 @@
+import { MongoClient } from 'mongodb'
+import {
+  createMeditationInputFactory,
+  updateMeditationInputFactory,
+} from 'domain/application/meditation/factory'
+import Act from 'domain/model/act'
+import actFactory from 'domain/model/act/factory'
+import Meditation from 'domain/model/meditation'
+import meditationFactory from 'domain/model/meditation/factory'
+import { createLoaders } from 'application'
+import meditationMutations from 'domain/application/meditation/mutations'
+
+describe('MeditationMutations', () => {
+  let connection
+  let db
+  let loaders
+  let meditationCollection
+  let actCollection
+  const _ = undefined
+
+  beforeAll(async () => {
+    connection = await MongoClient.connect(global.MONGO_URI, { useNewUrlParser: true })
+    db = await connection.db(global.MONGO_DB_NAME)
+    loaders = createLoaders(db)
+    meditationCollection = db.collection(Meditation.name.toLowerCase())
+    actCollection = db.collection(Act.name.toLowerCase())
+  })
+
+  beforeEach(async () => {
+    await meditationCollection.removeMany()
+    await actCollection.removeMany()
+  })
+
+  afterAll(async () => {
+    await connection.close()
+    await db.close()
+  })
+
+  it('should create an Meditation domain object', async () => {
+    const mockCreateMeditationInput = createMeditationInputFactory()
+    const insertedMeditation = await meditationMutations.createMeditation(_, { input: mockCreateMeditationInput }, { db, loaders })
+    const meditationCollectionDocs = await meditationCollection.find().toArray()
+    expect(meditationCollectionDocs.length).toEqual(1)
+    const { acts: insertedMeditationActs, ...insertedMeditationInfo } = insertedMeditation
+    const { acts: mockCreateMeditationInputActs, ...mockCreateMeditationInputInfo } = mockCreateMeditationInput
+    expect(insertedMeditationInfo)
+      .toEqual(expect.objectContaining(mockCreateMeditationInputInfo))
+    expect(insertedMeditationActs[0])
+      .toEqual(expect.objectContaining(mockCreateMeditationInputActs[0]))
+  })
+
+  it('should update an Meditation domain object', async () => {
+    const mockMeditation = meditationFactory()
+    const mockUpdateMeditationInput = updateMeditationInputFactory(1, mockMeditation._id)
+    await meditationCollection.insertOne(mockMeditation.toJSON())
+    const updatedMeditation = await meditationMutations.updateMeditation(_, { input: mockUpdateMeditationInput }, { db, loaders })
+    expect({ ...mockUpdateMeditationInput, meditationId: updatedMeditation.meditationId, _id: mockUpdateMeditationInput.id })
+      .toEqual(expect.objectContaining(updatedMeditation))
+  })
+
+  it('should delete one Meditation domain object given id', async () => {
+    const mockMeditation = meditationFactory()
+    const mockActs = actFactory(2, _, _, _, mockMeditation._id)
+    await actCollection.insertMany(mockActs.map(mockAct => mockAct.toJSON()))
+    await meditationCollection.insertOne(mockMeditation.toJSON())
+    await meditationMutations.deleteMeditation(_, { id: mockMeditation._id }, { db, loaders })
+    const meditationCollectionDocs = await meditationCollection.find().toArray()
+    const actCollectionDocs = await actCollection.find().toArray()
+    expect(meditationCollectionDocs.length).toEqual(0)
+    expect(actCollectionDocs.length).toEqual(0)
+  })
+})

--- a/src/domain/application/meditation/queries.js
+++ b/src/domain/application/meditation/queries.js
@@ -3,6 +3,6 @@ import MeditationService from 'domain/service/meditation'
 export default {
   meditations: (_, args, context) => {
     const meditationService = MeditationService.build(context.db, context.loaders)
-    return meditationService.loadFromFilter(args.input)
+    return meditationService.loadByFilter(args.input)
   },
 }

--- a/src/domain/application/meditation/queries.test.js
+++ b/src/domain/application/meditation/queries.test.js
@@ -1,0 +1,44 @@
+import { MongoClient } from 'mongodb'
+import Act from 'domain/model/act'
+import actFactory from 'domain/model/act/factory'
+import Meditation from 'domain/model/meditation'
+import meditationFactory from 'domain/model/meditation/factory'
+import { createLoaders } from 'application'
+import meditationQueries from 'domain/application/meditation/queries'
+
+describe('MeditationQueries', () => {
+  let connection
+  let db
+  let loaders
+  let meditationCollection
+  let actCollection
+  const _ = undefined
+
+  beforeAll(async () => {
+    connection = await MongoClient.connect(global.MONGO_URI, { useNewUrlParser: true })
+    db = await connection.db(global.MONGO_DB_NAME)
+    loaders = createLoaders(db)
+    meditationCollection = db.collection(Meditation.name.toLowerCase())
+    actCollection = db.collection(Act.name.toLowerCase())
+  })
+
+  beforeEach(async () => {
+    await meditationCollection.removeMany()
+    await actCollection.removeMany()
+  })
+
+  afterAll(async () => {
+    await connection.close()
+    await db.close()
+  })
+
+  it('should delete one Meditation domain object given id', async () => {
+    const mockMeditation = meditationFactory()
+    const mockActs = actFactory(2, _, _, _, mockMeditation._id)
+    await actCollection.insertMany(mockActs.map(mockAct => mockAct.toJSON()))
+    await meditationCollection.insertOne(mockMeditation.toJSON())
+    const queriedMeditations = await meditationQueries.meditations(_, { input: { category: mockMeditation.category } }, { db, loaders })
+    expect(queriedMeditations.length).toEqual(1)
+    expect(queriedMeditations[0]).toEqual(expect.objectContaining(mockMeditation.toJSON()))
+  })
+})

--- a/src/domain/application/meditation/resolvers.js
+++ b/src/domain/application/meditation/resolvers.js
@@ -1,10 +1,8 @@
 export default {
-  Meditation: {
-    id(meditation) {
-      return meditation._id
-    },
-    acts(meditation, _, context) {
-      return context.loaders.meditationActsLoader.load(meditation._id)
-    },
+  id(meditation) {
+    return meditation._id
+  },
+  acts(meditation, _, context) {
+    return context.loaders.meditationActsLoader.load(meditation._id)
   },
 }

--- a/src/domain/application/meditation/resolvers.test.js
+++ b/src/domain/application/meditation/resolvers.test.js
@@ -1,0 +1,50 @@
+import { MongoClient } from 'mongodb'
+import Act from 'domain/model/act'
+import actFactory from 'domain/model/act/factory'
+import Meditation from 'domain/model/meditation'
+import meditationFactory from 'domain/model/meditation/factory'
+import { createLoaders } from 'application'
+import meditationResolvers from 'domain/application/meditation/resolvers'
+
+describe('MeditationResolvers', () => {
+  let connection
+  let db
+  let loaders
+  let meditationCollection
+  let actCollection
+  const _ = undefined
+
+  beforeAll(async () => {
+    connection = await MongoClient.connect(global.MONGO_URI, { useNewUrlParser: true })
+    db = await connection.db(global.MONGO_DB_NAME)
+    loaders = createLoaders(db)
+    meditationCollection = db.collection(Meditation.name.toLowerCase())
+    actCollection = db.collection(Act.name.toLowerCase())
+  })
+
+  beforeEach(async () => {
+    await meditationCollection.removeMany()
+    await actCollection.removeMany()
+  })
+
+  afterAll(async () => {
+    await connection.close()
+    await db.close()
+  })
+
+  it('should return an Meditation domain object id', () => {
+    const mockMeditation = meditationFactory()
+    const resolvedMeditationId = meditationResolvers.id(mockMeditation)
+    expect(resolvedMeditationId).toEqual(mockMeditation._id)
+  })
+
+  it('should return and array of Act objects given one Meditation domain object', async () => {
+    const mockMeditation = meditationFactory()
+    const mockActs = actFactory(2, _, _, _, mockMeditation._id)
+    await actCollection.insertMany(mockActs.map(mockAct => mockAct.toJSON()))
+    await meditationCollection.insertOne(mockMeditation.toJSON())
+    const loadedActs = await meditationResolvers.acts(mockMeditation, _, { db, loaders })
+    expect(loadedActs)
+      .toEqual(expect.arrayContaining(mockActs.map(mockAct => mockAct.toJSON())))
+  })
+})

--- a/src/domain/model/act/repository.js
+++ b/src/domain/model/act/repository.js
@@ -23,7 +23,7 @@ export default class ActRepository {
 
   async load(id) {
     const loadedDocument = await this.act_collection
-      .findOne({ _id: id }, this.transaction)
+      .findOne({ _id: id })
     if (!loadedDocument) {
       throw new ApolloError('Act not found', 'NOT_FOUND')
     } else {
@@ -31,28 +31,23 @@ export default class ActRepository {
     }
   }
 
-  loadByIds(ids) {
-    return this.act_collection
+  async loadByIds(ids) {
+    const loadedDocuments = await this.act_collection
       .find({ _id: { $in: ids } })
       .toArray()
+    return loadedDocuments.map(loadedDocument => new Act(loadedDocument))
   }
 
-  async loadByMeditationId(meditationIds) {
+  async loadByMeditationsIds(meditationIds) {
     const loadedActs = await this.act_collection
-      .find({ meditationId: { $in: meditationIds } }, this.transaction)
+      .find({ meditationId: { $in: meditationIds } })
       .toArray()
     return loadedActs.map(act => new Act(act))
   }
 
-  batchLoadByMeditationsIds(meditationIds) {
-    return this.act_collection
-      .find({ meditationId: { $in: meditationIds } })
-      .toArray()
-  }
-
   async replace(act) {
     const replacedDocument = await this.act_collection
-      .replaceOne({ _id: act._id }, act, this.transaction)
+      .replaceOne({ _id: act._id }, act)
       .then((res) => {
         if (res.matchedCount !== 1) {
           throw new ApolloError('Act not found', 'NOT_FOUND')

--- a/src/domain/model/act/repository.test.js
+++ b/src/domain/model/act/repository.test.js
@@ -76,7 +76,7 @@ describe('ActRepository', () => {
     mockActs[1].meditationId = 'efgh'
     await actCollection.insertMany(mockActs.map(act => act.toJSON()))
     const actRepository = new ActRepository(db)
-    const loadedActs = await actRepository.loadByMeditationId(['abcd'])
+    const loadedActs = await actRepository.loadByMeditationsIds(['abcd'])
     expect(loadedActs.length).toBe(1)
     expect(loadedActs[0].toJSON()).toEqual(mockActs[0].toJSON())
   })
@@ -85,7 +85,7 @@ describe('ActRepository', () => {
     const mockActs = actFactory(3, _, _, 'abcd')
     await actCollection.insertMany(mockActs.map(act => act.toJSON()))
     const actRepository = new ActRepository(db)
-    const loadedActs = await actRepository.loadByMeditationId(['efgh'])
+    const loadedActs = await actRepository.loadByMeditationsIds(['efgh'])
     expect(loadedActs.length).toBe(0)
   })
 
@@ -156,27 +156,25 @@ describe('ActRepository', () => {
     const actRepository = new ActRepository(db)
     await actCollection.insertMany(mockActs.map(mockAct => mockAct.toJSON()))
     const loadedActs = await actRepository.loadByIds(mockActs.map(mockAct => mockAct._id))
-    expect(loadedActs).toEqual(expect.arrayContaining(mockActs.map(mockAct => mockAct.toJSON())))
     expect(loadedActs.map(loadedAct => loadedAct._id)).toEqual(expect.arrayContaining(mockActs.map(mockAct => mockAct._id)))
   })
 
-  it('should batchLoadByMeditationsIds', async () => {
+  it('should loadByMeditationsIds', async () => {
     const mockActs = actFactory(4, _, _, _, 'foo')
     mockActs[3].meditationId = 'bar'
     const actRepository = new ActRepository(db)
     await actCollection.insertMany(mockActs.map(mockAct => mockAct.toJSON()))
-    const loadedActs = await actRepository.batchLoadByMeditationsIds(['bar', 'foo'])
-    expect(loadedActs).toEqual(expect.arrayContaining(
-      [mockActs[3].toJSON()],
-      mockActs.slice(0, 3).map(mockAct => mockAct.toJSON()),
-    ))
+    const loadedActs = await actRepository.loadByMeditationsIds(['bar', 'foo'])
+    expect(loadedActs.length).toEqual(4)
+    expect(loadedActs.map(loadedAct => loadedAct.toJSON()))
+      .toEqual(expect.arrayContaining(mockActs.map(mockAct => mockAct.toJSON())))
   })
 
   it('should return empty array when batchLoadByMeditationsIds with a id not into the collection', async () => {
     const mockActs = actFactory(4, _, _, _, 'foo')
     const actRepository = new ActRepository(db)
     await actCollection.insertMany(mockActs.map(mockAct => mockAct.toJSON()))
-    const loadedActs = await actRepository.batchLoadByMeditationsIds(['bar'])
+    const loadedActs = await actRepository.loadByMeditationsIds(['bar'])
     expect(loadedActs).toEqual([])
   })
 })

--- a/src/domain/model/meditation/repository.test.js
+++ b/src/domain/model/meditation/repository.test.js
@@ -145,12 +145,13 @@ describe('MeditationRepository', () => {
       }))
   })
 
-  it('should batchLoadByIds', async () => {
+  it('should batch load by meditation ids', async () => {
     const mockMeditations = meditationFactory(4)
     const meditationRepository = new MeditationRepository(db)
     await meditationCollection.insertMany(mockMeditations.map(mockMeditation => mockMeditation.toJSON()))
-    const loadedMeditations = await meditationRepository.batchLoadByIds(mockMeditations.map(mockMeditation => mockMeditation._id))
+    const loadedMeditations = await meditationRepository.loadByIds(mockMeditations.map(mockMeditation => mockMeditation._id))
     expect(loadedMeditations).toEqual(expect.arrayContaining(mockMeditations.map(mockMeditation => mockMeditation.toJSON())))
-    expect(loadedMeditations.map(loadedMeditation => loadedMeditation._id)).toEqual(mockMeditations.map(mockMeditation => mockMeditation._id))
+    expect(loadedMeditations.map(loadedMeditation => loadedMeditation._id))
+      .toEqual(expect.arrayContaining(mockMeditations.map(mockMeditation => mockMeditation._id)))
   })
 })

--- a/src/domain/service/act/index.test.js
+++ b/src/domain/service/act/index.test.js
@@ -35,7 +35,7 @@ describe('ActService', () => {
 
   it('should build', async () => {
     const mockedDb = {
-      collection: jest.fn(() => 'foo')
+      collection: jest.fn(() => 'foo'),
     }
     const actService = ActService.build(mockedDb, 'baz')
     expect(actService.actRepository).toBeInstanceOf(ActRepository)
@@ -109,13 +109,13 @@ describe('ActService', () => {
   it('should delete new act given a valid id', async () => {
     const mockActs = actFactory(2)
     actRepository.load = jest.fn(() => mockActs[0])
-    actRepository.loadByMeditationId = jest.fn(() => mockActs)
+    actRepository.loadByMeditationsIds = jest.fn(() => mockActs)
     const actService = new ActService(actRepository, loaders)
     await actService.delete(mockActs[0]._id)
     expect(actRepository.load).toHaveBeenCalledTimes(1)
     expect(actRepository.load).toHaveBeenCalledWith(mockActs[0]._id)
-    expect(actRepository.loadByMeditationId).toHaveBeenCalledTimes(1)
-    expect(actRepository.loadByMeditationId).toHaveBeenCalledWith([mockActs[0].meditationId])
+    expect(actRepository.loadByMeditationsIds).toHaveBeenCalledTimes(1)
+    expect(actRepository.loadByMeditationsIds).toHaveBeenCalledWith([mockActs[0].meditationId])
     expect(actRepository.delete).toHaveBeenCalledTimes(1)
     expect(actRepository.delete).toHaveBeenCalledWith(mockActs[0]._id)
     expect(loaders.actLoader.clear).toHaveBeenCalledTimes(1)
@@ -127,7 +127,7 @@ describe('ActService', () => {
   it('should throw error when deleting act when it is the only child', async () => {
     const mockAct = actFactory()
     actRepository.load = jest.fn(() => mockAct)
-    actRepository.loadByMeditationId = jest.fn(() => [1])
+    actRepository.loadByMeditationsIds = jest.fn(() => [1])
     const actService = new ActService(actRepository, loaders)
     await expect(actService.delete(mockAct._id))
       .rejects
@@ -139,8 +139,8 @@ describe('ActService', () => {
       }))
     expect(actRepository.load).toHaveBeenCalledTimes(1)
     expect(actRepository.load).toHaveBeenCalledWith(mockAct._id)
-    expect(actRepository.loadByMeditationId).toHaveBeenCalledTimes(1)
-    expect(actRepository.loadByMeditationId).toHaveBeenCalledWith([mockAct.meditationId])
+    expect(actRepository.loadByMeditationsIds).toHaveBeenCalledTimes(1)
+    expect(actRepository.loadByMeditationsIds).toHaveBeenCalledWith([mockAct.meditationId])
     expect(actRepository.delete).not.toHaveBeenCalled()
     expect(loaders.actLoader.clear).not.toHaveBeenCalled()
     expect(loaders.meditationActsLoader.clear).not.toHaveBeenCalled()
@@ -168,7 +168,7 @@ describe('ActService', () => {
     const mockActs = actFactory(2)
     actRepository.loadByIds = jest.fn(() => Promise.resolve(mockActs))
     const actService = new ActService(actRepository)
-    const orderedActs = await actService.batchLoadByIds([
+    const orderedActs = await actService.loadByIds([
       mockActs[1]._id,
       mockActs[0]._id,
     ])
@@ -181,9 +181,9 @@ describe('ActService', () => {
   it('should batchLoadByIds given array of meditationIds', async () => {
     const mockActs = actFactory(4, _, _, _, 'foo')
     mockActs[3].meditationId = 'bar'
-    actRepository.batchLoadByMeditationsIds = jest.fn(() => Promise.resolve(mockActs))
+    actRepository.loadByMeditationsIds = jest.fn(() => Promise.resolve(mockActs))
     const actService = new ActService(actRepository)
-    const orderedActs = await actService.batchLoadByMeditationsIds([
+    const orderedActs = await actService.loadByMeditationsIds([
       'bar',
       'foo',
     ])

--- a/src/domain/service/act/loaders.js
+++ b/src/domain/service/act/loaders.js
@@ -5,11 +5,11 @@ export default {
   actLoader: db =>
     new DataLoader((actsIds) => {
       const actService = ActService.build(db)
-      return actService.batchLoadByIds(actsIds)
+      return actService.loadByIds(actsIds)
     }),
   meditationActsLoader: db =>
     new DataLoader((meditationsIds) => {
       const actService = ActService.build(db)
-      return actService.batchLoadByMeditationsIds(meditationsIds)
+      return actService.loadByMeditationsIds(meditationsIds)
     }),
 }

--- a/src/domain/service/act/loaders.test.js
+++ b/src/domain/service/act/loaders.test.js
@@ -19,14 +19,14 @@ describe('ActLoaders', () => {
   it('should create ActLoader', async () => {
     const actLoader = ActLoaders.actLoader()
     await actLoader._batchLoadFn(['foo', 'bar'])
-    expect(actService.batchLoadByIds).toHaveBeenCalledTimes(1)
-    expect(actService.batchLoadByIds).toHaveBeenCalledWith(['foo', 'bar'])
+    expect(actService.loadByIds).toHaveBeenCalledTimes(1)
+    expect(actService.loadByIds).toHaveBeenCalledWith(['foo', 'bar'])
   })
 
   it('should create MeditationActsLoader', async () => {
     const actLoader = ActLoaders.meditationActsLoader()
     await actLoader._batchLoadFn(['foo', 'bar'])
-    expect(actService.batchLoadByMeditationsIds).toHaveBeenCalledTimes(1)
-    expect(actService.batchLoadByMeditationsIds).toHaveBeenCalledWith(['foo', 'bar'])
+    expect(actService.loadByMeditationsIds).toHaveBeenCalledTimes(1)
+    expect(actService.loadByMeditationsIds).toHaveBeenCalledWith(['foo', 'bar'])
   })
 })

--- a/src/domain/service/meditation/index.js
+++ b/src/domain/service/meditation/index.js
@@ -46,18 +46,15 @@ export default class MeditationService {
     return { ...meditation.toJSON(), acts: addedActs.map(act => act.toJSON()) }
   }
 
-  async loadFromFilter(filterInput) {
-    const loadedMeditations = await this.meditationRepository.loadFromFilter(filterInput)
+  async loadByFilter(filterInput) {
+    const loadedMeditations = await this.meditationRepository.loadByFilter(filterInput)
     return loadedMeditations
   }
 
-  batchLoadByIds(ids) {
-    const loadedMeditations = this.meditationRepository.loadByIds(ids)
-    return loadedMeditations
-      .then((meditations) => {
-        const meditationsById = indexBy(prop('_id'), meditations)
-        return ids.map(meditationsId => meditationsById[meditationsId])
-      })
+  async loadByIds(ids) {
+    const loadedMeditations = await this.meditationRepository.loadByIds(ids)
+    const meditationsById = indexBy(prop('_id'), loadedMeditations)
+    return ids.map(meditationsId => meditationsById[meditationsId])
   }
 
   async update(updateInput) {
@@ -82,7 +79,7 @@ export default class MeditationService {
     const meditation = await this.meditationRepository.load(id)
     if (meditation) {
       await this.meditationRepository.delete(id)
-      const meditationActs = await this.actRepository.loadByMeditationId(meditation._id)
+      const meditationActs = await this.actRepository.loadByMeditationsIds([meditation._id])
       await this.actRepository.deleteMany(meditationActs.map(act => act._id))
       this.loaders.meditationLoader.clear(id)
       meditationActs.map(act => this.loaders.actLoader.clear(act._id))

--- a/src/domain/service/meditation/index.test.js
+++ b/src/domain/service/meditation/index.test.js
@@ -114,14 +114,14 @@ describe('MeditationService', () => {
     expect(loaders.meditationActsLoader.clear).not.toHaveBeenCalled()
   })
 
-  it('should call loadFromFilter correctly when load have been called', async () => {
+  it('should call loadByFilter correctly when load have been called', async () => {
     const mockMeditations = meditationFactory(2)
-    meditationRepository.loadFromFilter = jest.fn(() => mockMeditations)
+    meditationRepository.loadByFilter = jest.fn(() => mockMeditations)
     const meditationService = new MeditationService(meditationRepository, actRepository, loaders)
     const input = meditationsInputFilterFactory()
-    const addedMeditation = await meditationService.loadFromFilter(input)
-    expect(meditationRepository.loadFromFilter).toHaveBeenCalledTimes(1)
-    expect(meditationRepository.loadFromFilter).toHaveBeenCalledWith(input)
+    const addedMeditation = await meditationService.loadByFilter(input)
+    expect(meditationRepository.loadByFilter).toHaveBeenCalledTimes(1)
+    expect(meditationRepository.loadByFilter).toHaveBeenCalledWith(input)
     expect(addedMeditation).toEqual(expect.arrayContaining(mockMeditations))
   })
 
@@ -129,7 +129,7 @@ describe('MeditationService', () => {
     const mockMeditations = meditationFactory(2)
     meditationRepository.loadByIds = jest.fn(() => Promise.resolve(mockMeditations))
     const meditationService = new MeditationService(meditationRepository)
-    const orderedMeditations = await meditationService.batchLoadByIds([
+    const orderedMeditations = await meditationService.loadByIds([
       mockMeditations[1]._id,
       mockMeditations[0]._id,
     ])
@@ -180,7 +180,7 @@ describe('MeditationService', () => {
     const mockMeditation = meditationFactory()
     const mockActs = actFactory(2)
     meditationRepository.load = jest.fn(() => mockMeditation)
-    actRepository.loadByMeditationId = jest.fn(() => mockActs)
+    actRepository.loadByMeditationsIds = jest.fn(() => mockActs)
     const meditationService = new MeditationService(meditationRepository, actRepository, loaders)
     await meditationService.delete(mockMeditation._id)
     expect(meditationRepository.load).toHaveBeenCalledTimes(1)

--- a/src/domain/service/meditation/loaders.js
+++ b/src/domain/service/meditation/loaders.js
@@ -5,6 +5,6 @@ export default {
   meditationLoader: db =>
     new DataLoader((meditationsIds) => {
       const meditationService = MeditationService.build(db)
-      return meditationService.batchLoadByIds(meditationsIds)
+      return meditationService.loadByIds(meditationsIds)
     }),
 }

--- a/src/domain/service/meditation/loaders.test.js
+++ b/src/domain/service/meditation/loaders.test.js
@@ -19,7 +19,7 @@ describe('MeditationLoaders', () => {
   it('shoudl create MeditationLoader', async () => {
     const meditationLoader = MeditationLoaders.meditationLoader()
     await meditationLoader._batchLoadFn(['foo', 'bar'])
-    expect(meditationService.batchLoadByIds).toHaveBeenCalledTimes(1)
-    expect(meditationService.batchLoadByIds).toHaveBeenCalledWith(['foo', 'bar'])
+    expect(meditationService.loadByIds).toHaveBeenCalledTimes(1)
+    expect(meditationService.loadByIds).toHaveBeenCalledWith(['foo', 'bar'])
   })
 })


### PR DESCRIPTION
Closes #11 and #1 adding tests to all the resolvers to ensure they are well stitched and move loaders functions inside `async`